### PR TITLE
chore: upload pet verification mock api 생성 [#44]

### DIFF
--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -6,5 +6,5 @@ export const BACKEND_ENDPOINT = import.meta.env.DEV
 
 export const END_POINT = {
   HOME: `/api/home`,
-  UPLOAD: '/api/posts',
+  POST: '/api/post',
 } as const;

--- a/src/mocks/handlers/verification.ts
+++ b/src/mocks/handlers/verification.ts
@@ -6,4 +6,7 @@ import { verification } from '../resolvers/verification';
 export const verificationHandler = [
   /** verification count 및 pet info 조회 */
   http.get(baseURL(END_POINT.HOME), verification.getVerificationCount.success),
+
+  /** pet verification post */
+  http.post(baseURL(END_POINT.POST), verification.uploadVerification.success),
 ];

--- a/src/mocks/resolvers/verification.ts
+++ b/src/mocks/resolvers/verification.ts
@@ -1,13 +1,27 @@
 import { HttpResponse, delay } from 'msw';
 
 import { verificationCountInfo } from '../datas/verification';
+import { MSWResolvers } from '../../utils/mswUtils';
+import { UploadVerificationContents } from '../../types/verification';
 
 export const verification = {
   getVerificationCount: {
     success: async () => {
       await delay();
-
       return HttpResponse.json(verificationCountInfo);
     },
   },
-};
+
+  uploadVerification: {
+    success: async ({ request }) => {
+      await delay();
+      const postVerification =
+        (await request.json()) as UploadVerificationContents;
+      const uploadedVerification: UploadVerificationContents = {
+        ...postVerification,
+        imageUrl: postVerification.imageUrl,
+      };
+      return HttpResponse.json(uploadedVerification);
+    },
+  },
+} satisfies MSWResolvers;

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -1,7 +1,7 @@
 import { GENDER_TYPE } from '../constants/pet';
 import { VERIFICATION } from '../constants/verifications';
 
-export interface UploadVerification {
+export interface UploadVerificationContents {
   category: (typeof VERIFICATION)[keyof typeof VERIFICATION];
   imageUrl?: string;
   comment?: string;
@@ -20,3 +20,15 @@ export interface VerificationCount {
     treatsCount: number;
   };
 }
+
+export interface WalkOption extends DefaultOption {
+  hour?: string;
+  minutes?: string;
+}
+
+export interface DefaultOption {
+  verificationOption?: string;
+  comment?: string;
+  imageUrl?: File[];
+}
+export type UploadVerificationForm = WalkOption | DefaultOption;


### PR DESCRIPTION
### 관련 문서

Closes #44 

### 변경사항:

upload pet verification mock api 생성하였습니다.
- endpoint  및 상수들은 api가 확정되고나서 변경 될 수 있습니다.

### 확인할 목록:

