### PR TITLE
chore: 협업을 위한 카카오 로그인 코드 수정 [#60]

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -71,6 +71,10 @@ const BottomBar = () => {
   );
 };
 const Layout = ({ top, children }: { top?: TopBar; children: ReactNode }) => {
+  const navigate = useNavigate();
+  if (!localStorage.getItem('token')) {
+    navigate(ROUTE_PATH.INTRO);
+  }
   return (
     <S.Container>
       {top && <TopBar {...top} />}

--- a/src/pages/KakaoLogIn.tsx
+++ b/src/pages/KakaoLogIn.tsx
@@ -1,42 +1,7 @@
-import axios from 'axios';
-import QueryString from 'qs';
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import ROUTE_PATH from '../router/constants';
-
-const {
-  VITE_KAKAO_REST_API_KEY,
-  VITE_KAKAO_REDIRECT_URI,
-  VITE_KAKAO_CLIENT_SECRET,
-} = import.meta.env;
-
 const KakaoLogIn = () => {
-  const navigate = useNavigate();
-  useEffect(() => {
-    const code = new URL(window.location.href).searchParams.get('code');
+  const code = new URL(window.location.href).searchParams.get('code');
 
-    const getToken = async () => {
-      const payload = QueryString.stringify({
-        grant_type: 'authorization_code',
-        client_id: VITE_KAKAO_REST_API_KEY,
-        redirect_uri: VITE_KAKAO_REDIRECT_URI,
-        code: code,
-        client_secret: VITE_KAKAO_CLIENT_SECRET,
-      });
-      try {
-        const response = await axios.post(
-          'https://kauth.kakao.com/oauth/token',
-          payload
-        );
-        // response.data 에서 access_token 과 refresh_token이 존재함
-        console.log(response);
-        navigate(ROUTE_PATH.REGISTER_PET);
-      } catch (error) {
-        console.error(error);
-      }
-    };
-    getToken();
-  }, [navigate]);
+  console.log(code);
 
   return (
     <div>

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -1,7 +1,7 @@
 const ROUTE_PATH = {
   ROOT: '/',
   HOME: '',
-  INTRO: 'intro',
+  INTRO: '/intro',
   KAKAO_LOGIN: '/oauth/kakao/callback',
   REGISTER_PET: '/register/pet',
   REGISTER_PEOPLE: '/register/people',


### PR DESCRIPTION
### 관련 문서

<!--이슈 링크-->
<!--Closes 뒤에 본 PR을 머지하면 close할 issue number를 적어주세요.-->

Closes #60 

### 변경사항:

<!--중요 커밋은 링크로 연결해서 추가-->
클라이언트에서 access token과 refresh token까지 받고있던 로직을 백엔드에 줄 code까지만 진행되게끔 코드를 수정한다.
- 이는 토큰이 클라이언트에서 노출되면 보안의 위험이 따르기 떄문이다.

현재 인증인가 로직이 구현되어있지 않아서 기본적으로  intro 페이지로 라우팅 되게끔 조정하였습니다.

### 확인할 목록:

<!--리뷰어에게 부탁할 확인 목록 및 테스트 방법을 작성-->
