### PR TITLE
Feature #62 auth layout 생성

### DIFF
--- a/src/layout/AuthLayout.tsx
+++ b/src/layout/AuthLayout.tsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import ROUTE_PATH from '../router/constants';
+
+const AuthLayout = () => {
+  if (!localStorage.getItem('token')) return <Navigate to={ROUTE_PATH.INTRO} />;
+
+  return <Outlet />;
+};
+
+export default AuthLayout;

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -1,13 +1,15 @@
 import Button from '../components/Button';
 import { Dog, Ellipse, HeartCircle, KaKaoIcon } from '../components/Icons';
+import ROUTE_PATH from '../router/constants';
 
 import * as S from './Intro.styled';
 
-const { VITE_KAKAO_REST_API_KEY, VITE_KAKAO_REDIRECT_URI } = import.meta.env;
+const { VITE_KAKAO_REST_API_KEY } = import.meta.env;
 
 const Intro = () => {
-  const link = `https://kauth.kakao.com/oauth/authorize?client_id=${VITE_KAKAO_REST_API_KEY}&redirect_uri=${VITE_KAKAO_REDIRECT_URI}&response_type=code`;
+  const REDIRECT_URI = `${window.location.origin}${ROUTE_PATH.KAKAO_LOGIN}`;
 
+  const link = `https://kauth.kakao.com/oauth/authorize?client_id=${VITE_KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
   const loginHandler = () => {
     window.location.href = link;
   };

--- a/src/pages/KakaoLogIn.tsx
+++ b/src/pages/KakaoLogIn.tsx
@@ -1,12 +1,23 @@
-const KakaoLogIn = () => {
-  const code = new URL(window.location.href).searchParams.get('code');
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import ROUTE_PATH from '../router/constants';
+import { useEffect } from 'react';
 
-  console.log(code);
+const KakaoLogIn = () => {
+  const navigate = useNavigate();
+  const [search] = useSearchParams();
+  const code = search.get('code');
+
+  useEffect(() => {
+    if (code) {
+      localStorage.setItem('token', 'test');
+      navigate(ROUTE_PATH.ROOT);
+    }
+  }, [code, navigate]);
 
   return (
     <div>
       <p>로그인 중입니다.</p>
-      <p>잠시만 기다려주세요.와</p>
+      <p>잠시만 기다려주세요.</p>
     </div>
   );
 };

--- a/src/router/constants.ts
+++ b/src/router/constants.ts
@@ -1,6 +1,5 @@
 const ROUTE_PATH = {
   ROOT: '/',
-  HOME: '',
   INTRO: '/intro',
   KAKAO_LOGIN: '/oauth/kakao/callback',
   REGISTER_PET: '/register/pet',

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,6 +17,7 @@ import {
   SendingInvitation,
   FamilyList,
 } from '../pages';
+import AuthLayout from '../layout/AuthLayout';
 
 const router = createBrowserRouter([
   {
@@ -24,10 +25,6 @@ const router = createBrowserRouter([
     errorElement: <ErrorPage />,
     path: ROUTE_PATH.ROOT,
     children: [
-      {
-        element: <Home />,
-        path: ROUTE_PATH.HOME,
-      },
       {
         element: <Intro />,
         path: ROUTE_PATH.INTRO,
@@ -41,36 +38,46 @@ const router = createBrowserRouter([
         path: ROUTE_PATH.REGISTER_PET,
       },
       {
-        element: <Slide />,
-        path: ROUTE_PATH.SLIDE,
-      },
-      {
-        element: <Grid />,
-        path: ROUTE_PATH.GRID_BY_TYPE,
-      },
-      {
-        element: <GridByUser />,
-        path: ROUTE_PATH.GRID_BY_USER,
-      },
-      {
-        element: <Calendar />,
-        path: ROUTE_PATH.CALENDAR,
-      },
-      {
-        element: <Setting />,
-        path: ROUTE_PATH.SETTING,
-      },
-      {
-        element: <SendingInvitation />,
-        path: ROUTE_PATH.SENDING_INVITATION,
-      },
-      {
-        element: <FamilyList />,
-        path: ROUTE_PATH.FAMILY,
-      },
-      {
-        element: <UploadVerification />,
-        path: ROUTE_PATH.UPLOAD_VERIFICATION,
+        element: <AuthLayout />,
+        path: ROUTE_PATH.ROOT,
+        children: [
+          {
+            element: <Home />,
+            path: ROUTE_PATH.ROOT,
+          },
+          {
+            element: <Slide />,
+            path: ROUTE_PATH.SLIDE,
+          },
+          {
+            element: <Grid />,
+            path: ROUTE_PATH.GRID_BY_TYPE,
+          },
+          {
+            element: <GridByUser />,
+            path: ROUTE_PATH.GRID_BY_USER,
+          },
+          {
+            element: <Calendar />,
+            path: ROUTE_PATH.CALENDAR,
+          },
+          {
+            element: <Setting />,
+            path: ROUTE_PATH.SETTING,
+          },
+          {
+            element: <SendingInvitation />,
+            path: ROUTE_PATH.SENDING_INVITATION,
+          },
+          {
+            element: <FamilyList />,
+            path: ROUTE_PATH.FAMILY,
+          },
+          {
+            element: <UploadVerification />,
+            path: ROUTE_PATH.UPLOAD_VERIFICATION,
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
### 관련 문서

<!--이슈 링크-->
<!--Closes 뒤에 본 PR을 머지하면 close할 issue number를 적어주세요.-->

Closes #62 

### 변경사항:

<!--중요 커밋은 링크로 연결해서 추가-->
- auth layout 생성
    - 비로그인 시에는 기본적으로 Intro 페이지로 라우팅합니다.
    - 현재 login 로직을 연결하지않았기 때문에 기본적으로 카카오 로그인시 code가 존재하면 로그인 하게끔 합니다.(후에 수정 필요)
  

### 확인할 목록:

<!--리뷰어에게 부탁할 확인 목록 및 테스트 방법을 작성-->
