### PR TITLE
Feature #81  세팅화면 조회 API 호출

### DIFF
--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -1,0 +1,20 @@
+import apiClient from '.';
+import { END_POINT } from '../constants/endPoint';
+import { Family } from '../types/user';
+
+const userAPI = {
+  /** get family members */
+  getFamilyMembers: async (petId: string) => {
+    const { data } = await apiClient.get<Family>(END_POINT.FAMILY(petId));
+    return data;
+  },
+  /** invite member to family */
+  inviteMemberToFamily: async (petId: string, email: string) => {
+    const { data } = await apiClient.post(END_POINT.INVITE_MEMBER(petId), {
+      email,
+    });
+    return data;
+  },
+};
+
+export default userAPI;

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -9,7 +9,13 @@ const userAPI = {
     return data;
   },
   /** invite member to family */
-  inviteMemberToFamily: async (petId: string, email: string) => {
+  inviteMemberToFamily: async ({
+    petId,
+    email,
+  }: {
+    petId: string;
+    email: string;
+  }) => {
     const { data } = await apiClient.post(END_POINT.INVITE_MEMBER(petId), {
       email,
     });

--- a/src/api/verificationAPI.ts
+++ b/src/api/verificationAPI.ts
@@ -14,7 +14,7 @@ import type {
 
 const verificationAPI = {
   /** verification count 및 pet info 조회 */
-  getVerificationCount: async (petId: number) => {
+  getVerificationCount: async (petId: string) => {
     const query = qs.stringify({ petId: petId }, { skipNulls: true });
     const { data } = await apiClient.get<VerificationCount>(
       `${END_POINT.HOME}?${query}`

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -9,7 +9,7 @@ import VerificationButton from './components/VerificationButton';
 import * as S from './Home.styled';
 
 const Home = () => {
-  const { data, isLoading } = useVerificationCount({ petId: 1 });
+  const { data, isLoading } = useVerificationCount({ petId: '1' });
 
   return (
     <Layout>

--- a/src/pages/Home/hooks/queries.ts
+++ b/src/pages/Home/hooks/queries.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { verificationKey } from '../../../utils/query/queryKey';
 import verificationAPI from '../../../api/verificationAPI';
 
-export const useVerificationCount = ({ petId }: { petId: number }) => {
+export const useVerificationCount = ({ petId }: { petId: string }) => {
   return useQuery({
     queryKey: verificationKey.pet(petId),
     queryFn: () => verificationAPI.getVerificationCount(petId),

--- a/src/pages/setting/FamilyList.tsx
+++ b/src/pages/setting/FamilyList.tsx
@@ -1,32 +1,35 @@
 import { useNavigate } from 'react-router-dom';
+import { Suspense } from 'react';
 
+import { useFamilyMembers } from './hooks/queries';
 import UserImage from '../../components/UserImage';
 import { LeftArrowIcon } from '../../components/Icons';
 import FamilyItemList from './components/FamilyItemList';
 import ROUTE_PATH from '../../router/constants';
-import { familyMockData } from '../../utils/mockData';
 
 import * as G from './Setting.styled';
 import * as S from './FamilyList.styled';
 
-const userImageUrl =
-  'https://s3-alpha-sig.figma.com/img/53dd/e582/a7ad46483eb5c2a1714a957f9ff9efac?Expires=1712534400&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=kS~6xmYPqBB9e0p68RmqnmHwifQ0AzpBsJrENi-Nhre5ZIDc-nFa~TI3-VL8okScO7x3YbYWiXqPQUOD-235o6DQkn1rFXISXn5XOg4kAgU-asUxYmHk9gUESXPDblV3xECPnP1eh~TxMEklOc5cRZCeidVD07d1xk~Emh~u9tnOUqhE9CRNVLO3-ei456su8aKt3HrCnO1Ny~sXkoE5EdzX9k2K2Jznweio8n~NCoxpMC1rHX-RYooQeGGPynSjk4-LEWXRXv4eCEZJq-UcQ60v26iVTEnBMprTDV72XeKEn-TjUJWYmyJ8XLUSv8DZ5WcL6wWm4kA6QLoE46N2Iw__';
-
 const FamilyList = () => {
   const navigate = useNavigate();
+  const { data: familyMembers } = useFamilyMembers({ petId: '1' });
+
   return (
-    <>
+    <Suspense fallback={<div>로딩 중</div>}>
       <S.LoggedInUserField>
-        <LeftArrowIcon onClick={() => navigate(ROUTE_PATH.SETTING)} />
-        <UserImage size="XS" imageUrl={userImageUrl} />
+        <LeftArrowIcon
+          onClick={() => navigate(ROUTE_PATH.SETTING)}
+          style={{ cursor: 'pointer' }}
+        />
+        <UserImage size="XS" imageUrl={familyMembers.manager.imageUrl} />
       </S.LoggedInUserField>
       <S.FamilyWrapper>
         <G.FamilyTitle>
           <span>월이의 가족</span>
         </G.FamilyTitle>
-        <FamilyItemList family={familyMockData.slice(0, 1)} />
+        <FamilyItemList family={familyMembers.members} />
       </S.FamilyWrapper>
-    </>
+    </Suspense>
   );
 };
 export default FamilyList;

--- a/src/pages/setting/Setting.tsx
+++ b/src/pages/setting/Setting.tsx
@@ -1,48 +1,53 @@
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Layout } from '../../components';
 import { Message, RightArrowIcon } from '../../components/Icons';
 import UserImage from '../../components/UserImage';
 import VerificationField from '../Home/components/VerificationField';
-import { familyMockData, pet } from '../../utils/mockData';
 import ROUTE_PATH from '../../router/constants';
 import FamilyItemList from './components/FamilyItemList';
 import Switch from '../../components/Switch';
+import { useFamilyMembers } from './hooks/queries';
+import { useVerificationCount } from '../Home/hooks/queries';
 
 import * as S from './Setting.styled';
 
 const Setting = () => {
   const navigate = useNavigate();
   const [isAlarm, setIsAlarm] = useState(true);
+  const { data: familyMembers } = useFamilyMembers({ petId: '1' });
+  const { data: verificationCount } = useVerificationCount({ petId: '1' });
 
   return (
     <Layout>
       <S.Container>
         <S.LoggedInUserField>
-          <UserImage
-            size="XS"
-            imageUrl="https://s3-alpha-sig.figma.com/img/53dd/e582/a7ad46483eb5c2a1714a957f9ff9efac?Expires=1712534400&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=kS~6xmYPqBB9e0p68RmqnmHwifQ0AzpBsJrENi-Nhre5ZIDc-nFa~TI3-VL8okScO7x3YbYWiXqPQUOD-235o6DQkn1rFXISXn5XOg4kAgU-asUxYmHk9gUESXPDblV3xECPnP1eh~TxMEklOc5cRZCeidVD07d1xk~Emh~u9tnOUqhE9CRNVLO3-ei456su8aKt3HrCnO1Ny~sXkoE5EdzX9k2K2Jznweio8n~NCoxpMC1rHX-RYooQeGGPynSjk4-LEWXRXv4eCEZJq-UcQ60v26iVTEnBMprTDV72XeKEn-TjUJWYmyJ8XLUSv8DZ5WcL6wWm4kA6QLoE46N2Iw__"
-          />
+          <UserImage size="XS" imageUrl={familyMembers?.manager.imageUrl} />
         </S.LoggedInUserField>
-        <VerificationField pet={pet} />
+        <VerificationField pet={verificationCount} />
         <S.FamilyContainer>
           <S.FamilyTitle>
             <span>월이의 가족</span>
             <RightArrowIcon
               width={20}
-              hanging={11}
+              height={11}
               onClick={() => navigate(ROUTE_PATH.FAMILY)}
+              style={{ cursor: 'pointer' }}
             />
           </S.FamilyTitle>
-          <FamilyItemList family={familyMockData.slice(0, 1)} />
-          <S.MessageItem>
-            <Message />
-            <p id="message-body">
-              다른사람을 추가하고 싶다면 <br />
-              초대링크를 보내세요!
-            </p>
-          </S.MessageItem>
+          <Suspense fallback={<div>로딩 중</div>}>
+            <FamilyItemList family={familyMembers?.members} />
+            {familyMembers?.members.length === 1 && (
+              <S.MessageItem>
+                <Message />
+                <p id="message-body">
+                  다른사람을 추가하고 싶다면 <br />
+                  초대링크를 보내세요!
+                </p>
+              </S.MessageItem>
+            )}
+          </Suspense>
           <S.FamilyTitle>
             <span>월이의 가족</span>
             <S.SwitchWrapper $isAlarm={isAlarm}>

--- a/src/pages/setting/components/FamilyItemList.tsx
+++ b/src/pages/setting/components/FamilyItemList.tsx
@@ -3,21 +3,18 @@ import { useNavigate } from 'react-router-dom';
 import { PlusIcon } from '../../../components/Icons';
 import UserImage from '../../../components/UserImage';
 import ROUTE_PATH from '../../../router/constants';
-import { User } from '../../../utils/mockData';
+import { User } from '../../../types/user';
 
 import * as S from './FamilyItemList.styled';
 
-const FamilyItemList = ({ family }: { family: User[] }) => {
+const FamilyItemList = ({ family }: { family?: User[] }) => {
   const navigate = useNavigate();
   return (
     <S.FamilyWrapper>
-      {family.map((user) => (
-        <S.FamilyItem key={user.userId}>
-          <UserImage
-            size="SM"
-            imageUrl="https://s3-alpha-sig.figma.com/img/53dd/e582/a7ad46483eb5c2a1714a957f9ff9efac?Expires=1712534400&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=kS~6xmYPqBB9e0p68RmqnmHwifQ0AzpBsJrENi-Nhre5ZIDc-nFa~TI3-VL8okScO7x3YbYWiXqPQUOD-235o6DQkn1rFXISXn5XOg4kAgU-asUxYmHk9gUESXPDblV3xECPnP1eh~TxMEklOc5cRZCeidVD07d1xk~Emh~u9tnOUqhE9CRNVLO3-ei456su8aKt3HrCnO1Ny~sXkoE5EdzX9k2K2Jznweio8n~NCoxpMC1rHX-RYooQeGGPynSjk4-LEWXRXv4eCEZJq-UcQ60v26iVTEnBMprTDV72XeKEn-TjUJWYmyJ8XLUSv8DZ5WcL6wWm4kA6QLoE46N2Iw__"
-          />
-          <span>둘째딸</span>
+      {family?.map((user) => (
+        <S.FamilyItem key={user.id}>
+          <UserImage size="SM" imageUrl={user.imageUrl} />
+          <span>{user.name}</span>
         </S.FamilyItem>
       ))}
       <button

--- a/src/pages/setting/components/SendingInvitationForm.tsx
+++ b/src/pages/setting/components/SendingInvitationForm.tsx
@@ -7,6 +7,7 @@ import UserImage from '../../../components/UserImage';
 import { Button, Input } from '../../../components';
 
 import * as G from './settingGlobal.styled';
+import useInviteMember from '../hooks/mutation';
 
 interface SendingInvitation {
   email: string;
@@ -20,11 +21,16 @@ const SendingInvitationForm = ({ onNext }: { onNext: () => void }) => {
     formState: { errors },
   } = useForm<SendingInvitation>({ mode: 'onSubmit' });
   const navigate = useNavigate();
+  const mutation = useInviteMember();
+
+  // TODO: 현재 연결된 펫 데이터를 페칭해오는 api 와 쿼리훅 추가 필요
   const imageUrl = '';
 
   const onSubmit = (data: SendingInvitation) => {
     onNext();
     console.log(data);
+    // TODO: 현재 로그인된 유저가 조회하고 있는 pet Id를 최상단에서 저장하고 있어야한다.
+    mutation.mutate({ petId: '1', email: data.email });
   };
   const isValid = watch('email')?.length > 0 && !errors.email?.message;
 

--- a/src/pages/setting/hooks/mutation.ts
+++ b/src/pages/setting/hooks/mutation.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+
+import queryClient from '../../../utils/query/queryClient';
+import { userKey } from '../../../utils/query/queryKey';
+import userAPI from '../../../api/userAPI';
+
+const useInviteMember = () => {
+  return useMutation({
+    mutationFn: userAPI.inviteMemberToFamily,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: userKey.base,
+      });
+    },
+    onError: (error) => console.error(error),
+  });
+};
+export default useInviteMember;

--- a/src/pages/setting/hooks/queries.ts
+++ b/src/pages/setting/hooks/queries.ts
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { userKey } from '../../../utils/query/queryKey';
+import userAPI from '../../../api/userAPI';
+
+export const useFamilyMembers = ({ petId }: { petId: string }) => {
+  return useSuspenseQuery({
+    queryKey: userKey.family(petId),
+    queryFn: () => userAPI.getFamilyMembers(petId),
+  });
+};

--- a/src/utils/query/queryKey.ts
+++ b/src/utils/query/queryKey.ts
@@ -2,7 +2,7 @@ import { SortType } from '../../types/verification';
 
 export const verificationKey = {
   base: ['verification'] as const,
-  pet: (petId: number) => [...verificationKey.base, petId] as const,
+  pet: (petId: string) => [...verificationKey.base, petId] as const,
   grid: () => [...verificationKey.base, 'grid'] as const,
   allGrid: (sort: SortType) =>
     [...verificationKey.grid(), 'all', sort] as const,
@@ -11,4 +11,10 @@ export const verificationKey = {
     [...verificationKey.base, userId, sort] as const,
   slide: () => [...verificationKey.base, 'slide'] as const,
   calendar: () => [...verificationKey.base, 'calendar'] as const,
+};
+
+export const userKey = {
+  base: ['user'],
+  user: (userId: string) => [...userKey.base, userId] as const,
+  family: (petId: string) => [...userKey.base, petId, 'family'] as const,
 };


### PR DESCRIPTION
### 관련 문서

<!--이슈 링크-->
<!--Closes 뒤에 본 PR을 머지하면 close할 issue number를 적어주세요.-->

Closes #81 

### 변경사항:

<!--중요 커밋은 링크로 연결해서 추가-->
- 세팅화면에 렌더되는 family members 호출 및 렌더

|세팅화면| 패밀리 리스트 화면|
|-|-|  
|<img width="300" alt="image" src="https://github.com/meong-story/meong-story-FE/assets/60846068/65b8efab-eae0-4c5d-873c-6bbaed4def04">|<img width="300" alt="image" src="https://github.com/meong-story/meong-story-FE/assets/60846068/3dc6348f-b590-4fec-bb9d-6868285f5431">|
  
- 가족 멤버에 한 명만 존재한다면 알람 상태 표시
<img width="300" alt="image" src="https://github.com/meong-story/meong-story-FE/assets/60846068/f21958d2-6cab-43d2-a7a9-7321dd7f4cc1">


- 공유링크 초대 링크보내기 폼에 연결되는 post 요청 연결

### 확인할 목록:

<!--리뷰어에게 부탁할 확인 목록 및 테스트 방법을 작성-->
- 현재 로그인한 유저와 연결된 pet 데이터를 호출하는 로직을 추가해야합니다. (API 설계 이후 연결 예정)