### PR TITLE
Feature #90 인증 인가 mock api  생성

### DIFF
--- a/src/entities/verification/api/useAPI.ts
+++ b/src/entities/verification/api/useAPI.ts
@@ -1,0 +1,11 @@
+import { END_POINT } from '../../../shared/constants/endPoint';
+import apiClient from '../../../shared/api';
+
+const userAPI = {
+  kakaoLogin: async () => {
+    const { data } = await apiClient.get(END_POINT.KAKAO_TOKEN);
+    return data;
+  },
+};
+
+export default userAPI;

--- a/src/entities/verification/api/useKakaoLogin.ts
+++ b/src/entities/verification/api/useKakaoLogin.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { userKey } from '../../../shared/lib/query/queryKey';
+import userAPI from './useAPI';
+
+const useKakaoLogin = () => {
+  return useQuery({
+    queryKey: userKey.kakaoLogin(),
+    queryFn: () => userAPI.kakaoLogin(),
+  });
+};
+export default useKakaoLogin;

--- a/src/mocks/handlers/family.ts
+++ b/src/mocks/handlers/family.ts
@@ -3,20 +3,24 @@ import { http } from 'msw';
 import { END_POINT } from '../../shared/constants/endPoint';
 import { family } from '../resolvers/family';
 import { baseURL } from '../../shared/lib/mswUtils';
+import withAuth from '../middleware/withAuth';
 
 export const familyHandler = [
   /** get family members */
-  http.get(baseURL(END_POINT.FAMILY(':petId')), family.getFamilyMembers),
+  http.get(
+    baseURL(END_POINT.FAMILY(':petId')),
+    withAuth(family.getFamilyMembers)
+  ),
 
   /** get empty family members */
   http.get(
     baseURL(END_POINT.FAMILY(':petId') + '/empty'),
-    family.getEmptyFamilyMembers
+    withAuth(family.getEmptyFamilyMembers)
   ),
 
   /** invite member to family */
   http.post(
     baseURL(END_POINT.INVITE_MEMBER(':petId')),
-    family.inviteMemberToFamily
+    withAuth(family.inviteMemberToFamily)
   ),
 ];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,6 +1,7 @@
 import { familyHandler } from './family';
+import { userHandler } from './user';
 import { verificationHandler } from './verification';
 
-const mockHandlers = [...verificationHandler, ...familyHandler];
+const mockHandlers = [...userHandler, ...verificationHandler, ...familyHandler];
 
 export default mockHandlers;

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -1,0 +1,10 @@
+import { http } from 'msw';
+
+import { END_POINT } from '../../shared/constants/endPoint';
+import { baseURL } from '../../shared/lib/mswUtils';
+import { user } from '../resolvers/user';
+
+export const userHandler = [
+  /** kakao login */
+  http.get(baseURL(END_POINT.KAKAO_TOKEN), user.getFamilyMembers),
+];

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -6,5 +6,5 @@ import { user } from '../resolvers/user';
 
 export const userHandler = [
   /** kakao login */
-  http.get(baseURL(END_POINT.KAKAO_TOKEN), user.getFamilyMembers),
+  http.get(baseURL(END_POINT.KAKAO_TOKEN), user.kakaoLogin),
 ];

--- a/src/mocks/handlers/verification.ts
+++ b/src/mocks/handlers/verification.ts
@@ -2,32 +2,45 @@ import { http } from 'msw';
 import { END_POINT } from '../../shared/constants/endPoint';
 import { verification } from '../resolvers/verification';
 import { baseURL } from '../../shared/lib/mswUtils';
+import withAuth from '../middleware/withAuth';
 
 export const verificationHandler = [
   /** verification count 및 pet info 조회 */
-  http.get(baseURL(END_POINT.HOME), verification.getVerificationCount),
+  http.get(
+    baseURL(END_POINT.HOME),
+    withAuth(verification.getVerificationCount)
+  ),
 
   /** pet verification post */
-  http.post(baseURL(END_POINT.POST), verification.uploadVerification),
+  http.post(baseURL(END_POINT.POST), withAuth(verification.uploadVerification)),
 
   /** get verification for calendar data */
-  http.get(baseURL(END_POINT.CALENDAR), verification.getVerificationCalendar),
+  http.get(
+    baseURL(END_POINT.CALENDAR),
+    withAuth(verification.getVerificationCalendar)
+  ),
 
   /** get verification for slide data */
-  http.get(baseURL(END_POINT.SLIDE), verification.getVerificationForSlide),
+  http.get(
+    baseURL(END_POINT.SLIDE),
+    withAuth(verification.getVerificationForSlide)
+  ),
 
   /** get verification for grid all data */
-  http.get(baseURL(END_POINT.GRID), verification.getVerificationForAllGrid),
+  http.get(
+    baseURL(END_POINT.GRID),
+    withAuth(verification.getVerificationForAllGrid)
+  ),
 
   /** get verification for grid by Uploader data */
   http.get(
     baseURL(END_POINT.GRID_BY_UPLOADER),
-    verification.getVerificationForGridByUploader
+    withAuth(verification.getVerificationForGridByUploader)
   ),
 
   /** get verification for one specific uploader grid data */
   http.get(
     baseURL(END_POINT.UPLOADER_GRID),
-    verification.getVerificationForUploaderGrid
+    withAuth(verification.getVerificationForUploaderGrid)
   ),
 ];

--- a/src/mocks/middleware/withAuth.ts
+++ b/src/mocks/middleware/withAuth.ts
@@ -1,0 +1,21 @@
+import {
+  DefaultBodyType,
+  HttpResponse,
+  HttpResponseResolver,
+  PathParams,
+} from 'msw';
+
+const withAuth = (
+  resolver: HttpResponseResolver<PathParams, DefaultBodyType, undefined>
+): HttpResponseResolver<PathParams, DefaultBodyType, undefined> => {
+  return async (input) => {
+    const { cookies } = input;
+    if (!cookies.access_token) {
+      return new HttpResponse('Authorization', { status: 401 });
+    }
+
+    return resolver(input);
+  };
+};
+
+export default withAuth;

--- a/src/mocks/resolvers/user.ts
+++ b/src/mocks/resolvers/user.ts
@@ -1,48 +1,15 @@
 import { HttpResponse, delay } from 'msw';
-import axios from 'axios';
-import qs from 'qs';
 
 import { MSWResolvers } from '../../shared/lib/mswUtils';
 
-const {
-  VITE_KAKAO_REST_API_KEY,
-  VITE_KAKAO_REDIRECT_URI,
-  VITE_KAKAO_CLIENT_SECRET,
-} = import.meta.env;
-
-interface ResponseKakaoLogin {
-  access_token: string;
-  expires_in: number;
-  refresh_token: string;
-  refresh_token_expires_in: number;
-  scope: string;
-  token_type: string;
-}
-
 export const user = {
-  getFamilyMembers: async ({ request }) => {
+  kakaoLogin: async () => {
     await delay();
-    const queryString = new URL(request.url).search;
-    const parsedQuery = qs.parse(queryString, { ignoreQueryPrefix: true });
-
-    const payload = qs.stringify({
-      grant_type: 'authorization_code',
-      client_id: VITE_KAKAO_REST_API_KEY,
-      redirect_uri: VITE_KAKAO_REDIRECT_URI,
-      code: parsedQuery.code,
-      client_secret: VITE_KAKAO_CLIENT_SECRET,
-    });
-
     try {
-      const { data } = await axios.post<ResponseKakaoLogin>(
-        'https://kauth.kakao.com/oauth/token',
-        payload
-      );
-
       // mocking 을 위하여 HttpOnly; Secure 미추가
-      const cookie = `access_token=${data.access_token}; Path=/; Max-Age=${data.expires_in};`;
+      const cookie = `access_token=access-token; Path=/; Max-Age=604800;`;
       return HttpResponse.json(
-        { data },
+        { data: '로그인 성공' },
         {
           headers: {
             'Set-Cookie': cookie,

--- a/src/mocks/resolvers/user.ts
+++ b/src/mocks/resolvers/user.ts
@@ -1,0 +1,57 @@
+import { HttpResponse, delay } from 'msw';
+import axios from 'axios';
+import qs from 'qs';
+
+import { MSWResolvers } from '../../shared/lib/mswUtils';
+
+const {
+  VITE_KAKAO_REST_API_KEY,
+  VITE_KAKAO_REDIRECT_URI,
+  VITE_KAKAO_CLIENT_SECRET,
+} = import.meta.env;
+
+interface ResponseKakaoLogin {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+  refresh_token_expires_in: number;
+  scope: string;
+  token_type: string;
+}
+
+export const user = {
+  getFamilyMembers: async ({ request }) => {
+    await delay();
+    const queryString = new URL(request.url).search;
+    const parsedQuery = qs.parse(queryString, { ignoreQueryPrefix: true });
+
+    const payload = qs.stringify({
+      grant_type: 'authorization_code',
+      client_id: VITE_KAKAO_REST_API_KEY,
+      redirect_uri: VITE_KAKAO_REDIRECT_URI,
+      code: parsedQuery.code,
+      client_secret: VITE_KAKAO_CLIENT_SECRET,
+    });
+
+    try {
+      const { data } = await axios.post<ResponseKakaoLogin>(
+        'https://kauth.kakao.com/oauth/token',
+        payload
+      );
+
+      // mocking 을 위하여 HttpOnly; Secure 미추가
+      const cookie = `access_token=${data.access_token}; Path=/; Max-Age=${data.expires_in};`;
+      return HttpResponse.json(
+        { data },
+        {
+          headers: {
+            'Set-Cookie': cookie,
+          },
+        }
+      );
+    } catch (error) {
+      console.error('Error fetching Kakao access token:', error);
+      return HttpResponse.error();
+    }
+  },
+} satisfies MSWResolvers;

--- a/src/shared/constants/endPoint.ts
+++ b/src/shared/constants/endPoint.ts
@@ -14,4 +14,5 @@ export const END_POINT = {
   UPLOADER_GRID: '/api/grid/:userId',
   FAMILY: (petId: string) => `/api/family/${petId}`,
   INVITE_MEMBER: (petId: string) => `/api/family/${petId}/member`,
+  KAKAO_TOKEN: '/auth/kakao',
 } as const;

--- a/src/shared/constants/endPoint.ts
+++ b/src/shared/constants/endPoint.ts
@@ -14,5 +14,5 @@ export const END_POINT = {
   UPLOADER_GRID: '/api/grid/:userId',
   FAMILY: (petId: string) => `/api/family/${petId}`,
   INVITE_MEMBER: (petId: string) => `/api/family/${petId}/member`,
-  KAKAO_TOKEN: '/auth/kakao',
+  KAKAO_TOKEN: '/auth/kakao-login-page',
 } as const;


### PR DESCRIPTION
### 관련 문서

<!--이슈 링크-->
<!--Closes 뒤에 본 PR을 머지하면 close할 issue number를 적어주세요.-->

Closes #90

### 변경사항:

- 카카오 로그인에 사용되는 mock API를 생성하였습니다. 
- withAuth 고차함수를 만들어 로그인이 필요한 resolver에서 인증인가처리를 진행합니다.

##### 카카오 로그인 명세
- 엔드포인트 : `/auth/kakao-login-page`
- 카카오 로그인 으로 부터 redirect URI와 code 전달은 백엔드에서 처리하는 것으로 진행
<!--중요 커밋은 링크로 연결해서 추가-->

### 확인할 목록:

- 개발을 위하여 mocking api 에서 `HttpOnly; Secure`를 추가하지 않는다.

<!--리뷰어에게 부탁할 확인 목록 및 테스트 방법을 작성-->
