### PR TITLE
Feature #92 인증 인가 : 카카오 로그인 mock API 변경 및 API 호출

### DIFF
--- a/src/entities/verification/api/useAPI.ts
+++ b/src/entities/verification/api/useAPI.ts
@@ -2,8 +2,17 @@ import { END_POINT } from '../../../shared/constants/endPoint';
 import apiClient from '../../../shared/api';
 
 const userAPI = {
-  kakaoLogin: async () => {
-    const { data } = await apiClient.get(END_POINT.KAKAO_TOKEN);
+  kakaoLogin: async (code: string) => {
+    const { data } = await apiClient.post<{
+      message: string;
+      accessToken: string;
+    }>(END_POINT.KAKAO_LOGIN, {
+      code,
+    });
+    return data;
+  },
+  checkLogin: async () => {
+    const { data } = await apiClient.post(END_POINT.LOGIN_CHECK);
     return data;
   },
 };

--- a/src/entities/verification/api/useKakaoLogin.ts
+++ b/src/entities/verification/api/useKakaoLogin.ts
@@ -1,12 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
-import { userKey } from '../../../shared/lib/query/queryKey';
 import userAPI from './useAPI';
 
 const useKakaoLogin = () => {
-  return useQuery({
-    queryKey: userKey.kakaoLogin(),
-    queryFn: () => userAPI.kakaoLogin(),
+  return useMutation({
+    mutationFn: (code: string) => userAPI.kakaoLogin(code),
   });
 };
 export default useKakaoLogin;

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -6,5 +6,5 @@ import { user } from '../resolvers/user';
 
 export const userHandler = [
   /** kakao login */
-  http.get(baseURL(END_POINT.KAKAO_TOKEN), user.kakaoLogin),
+  http.post(baseURL(END_POINT.KAKAO_LOGIN), user.kakaoLogin),
 ];

--- a/src/mocks/middleware/withAuth.ts
+++ b/src/mocks/middleware/withAuth.ts
@@ -9,8 +9,9 @@ const withAuth = (
   resolver: HttpResponseResolver<PathParams, DefaultBodyType, undefined>
 ): HttpResponseResolver<PathParams, DefaultBodyType, undefined> => {
   return async (input) => {
-    const { cookies } = input;
-    if (!cookies.access_token) {
+    const { request } = input;
+    const accessToken = request.headers.get('Authorization');
+    if (!accessToken) {
       return new HttpResponse('Authorization', { status: 401 });
     }
 

--- a/src/mocks/resolvers/user.ts
+++ b/src/mocks/resolvers/user.ts
@@ -1,15 +1,44 @@
-import { HttpResponse, delay } from 'msw';
+import { HttpResponse } from 'msw';
+import qs from 'qs';
 
 import { MSWResolvers } from '../../shared/lib/mswUtils';
+import axios from 'axios';
+
+const {
+  VITE_KAKAO_REST_API_KEY,
+  VITE_KAKAO_REDIRECT_URI,
+  VITE_KAKAO_CLIENT_SECRET,
+} = import.meta.env;
+
+interface KakaoLogin {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+  refresh_token_expires_in: number;
+  scope: string;
+  token_type: string;
+}
 
 export const user = {
-  kakaoLogin: async () => {
-    await delay();
+  kakaoLogin: async ({ request }) => {
+    const body = (await request.json()) as { code: string };
+
+    const payload = qs.stringify({
+      grant_type: 'authorization_code',
+      client_id: VITE_KAKAO_REST_API_KEY,
+      redirect_uri: VITE_KAKAO_REDIRECT_URI,
+      code: body.code,
+      client_secret: VITE_KAKAO_CLIENT_SECRET,
+    });
     try {
+      const { data } = await axios.post<KakaoLogin>(
+        'https://kauth.kakao.com/oauth/token',
+        payload
+      );
       // mocking 을 위하여 HttpOnly; Secure 미추가
-      const cookie = `access_token=access-token; Path=/; Max-Age=604800;`;
+      const cookie = `refresh_token=${data.refresh_token}; Path=/; Max-Age=604800; `;
       return HttpResponse.json(
-        { data: '로그인 성공' },
+        { message: '로그인을 성공했습니다.', accessToken: data.access_token },
         {
           headers: {
             'Set-Cookie': cookie,
@@ -17,8 +46,7 @@ export const user = {
         }
       );
     } catch (error) {
-      console.error('Error fetching Kakao access token:', error);
-      return HttpResponse.error();
+      console.error(error);
     }
   },
 } satisfies MSWResolvers;

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -6,14 +6,14 @@ import * as S from './Intro.styled';
 
 const { VITE_KAKAO_REST_API_KEY } = import.meta.env;
 
+const REDIRECT_URI = `${window.location.origin}${ROUTE_PATH.KAKAO_LOGIN}`;
+
+const link = `https://kauth.kakao.com/oauth/authorize?client_id=${VITE_KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+const loginHandler = () => {
+  window.location.href = link;
+};
+
 const Intro = () => {
-  const REDIRECT_URI = `${window.location.origin}${ROUTE_PATH.KAKAO_LOGIN}`;
-
-  const link = `https://kauth.kakao.com/oauth/authorize?client_id=${VITE_KAKAO_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
-  const loginHandler = () => {
-    window.location.href = link;
-  };
-
   return (
     <S.Container>
       <S.Title>

--- a/src/pages/KakaoLogIn.tsx
+++ b/src/pages/KakaoLogIn.tsx
@@ -1,18 +1,23 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import ROUTE_PATH from '../shared/constants/routePath';
 import { useEffect } from 'react';
+import useKakaoLogin from '../entities/verification/api/useKakaoLogin';
 
 const KakaoLogIn = () => {
   const navigate = useNavigate();
-  const [search] = useSearchParams();
-  const code = search.get('code');
+  const [searchParams] = useSearchParams();
+  const code = searchParams.get('code');
+  const { mutateAsync } = useKakaoLogin();
 
   useEffect(() => {
-    if (code) {
-      localStorage.setItem('token', 'test');
-      navigate(ROUTE_PATH.ROOT);
-    }
-  }, [code, navigate]);
+    (async () => {
+      if (code) {
+        const data = await mutateAsync(code);
+        localStorage.setItem('token', data.accessToken);
+        navigate(ROUTE_PATH.ROOT);
+      }
+    })();
+  }, [code, mutateAsync, navigate]);
 
   return (
     <div>

--- a/src/pages/KakaoLogIn.tsx
+++ b/src/pages/KakaoLogIn.tsx
@@ -1,7 +1,10 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import ROUTE_PATH from '../shared/constants/routePath';
 import { useEffect } from 'react';
+import styled from 'styled-components';
+
+import ROUTE_PATH from '../shared/constants/routePath';
 import useKakaoLogin from '../entities/verification/api/useKakaoLogin';
+import Spinner from '../shared/ui/Spinner';
 
 const KakaoLogIn = () => {
   const navigate = useNavigate();
@@ -20,11 +23,13 @@ const KakaoLogIn = () => {
   }, [code, mutateAsync, navigate]);
 
   return (
-    <div>
-      <p>로그인 중입니다.</p>
-      <p>잠시만 기다려주세요.</p>
-    </div>
+    <Container>
+      <Spinner />
+    </Container>
   );
 };
 
+const Container = styled.div`
+  height: 100vh;
+`;
 export default KakaoLogIn;

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -2,10 +2,12 @@ import { Navigate, Outlet } from 'react-router-dom';
 
 import ROUTE_PATH from '../shared/constants/routePath';
 
-const AuthLayout = () => {
+const AuthProvider = () => {
   if (!localStorage.getItem('token')) return <Navigate to={ROUTE_PATH.INTRO} />;
+
+  // 펫 등록 여부에 따라서 다르게 리디렉션 해줄 것
 
   return <Outlet />;
 };
 
-export default AuthLayout;
+export default AuthProvider;

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,9 +1,10 @@
 import { Navigate, Outlet } from 'react-router-dom';
 
 import ROUTE_PATH from '../shared/constants/routePath';
+import { tokenStorage } from '../shared/lib/tokenStorage';
 
 const AuthProvider = () => {
-  if (!localStorage.getItem('token')) return <Navigate to={ROUTE_PATH.INTRO} />;
+  if (!tokenStorage.getToken()) return <Navigate to={ROUTE_PATH.INTRO} />;
 
   // 펫 등록 여부에 따라서 다르게 리디렉션 해줄 것
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,7 +17,7 @@ import {
   SendingInvitation,
   FamilyList,
 } from './pages';
-import AuthLayout from './providers/AuthLayout';
+import AuthProvider from './providers/AuthProvider';
 
 const router = createBrowserRouter([
   {
@@ -34,13 +34,13 @@ const router = createBrowserRouter([
         path: ROUTE_PATH.KAKAO_LOGIN,
       },
       {
-        element: <Register />,
-        path: ROUTE_PATH.REGISTER_PET,
-      },
-      {
-        element: <AuthLayout />,
+        element: <AuthProvider />,
         path: ROUTE_PATH.ROOT,
         children: [
+          {
+            element: <Register />,
+            path: ROUTE_PATH.REGISTER_PET,
+          },
           {
             element: <Home />,
             path: ROUTE_PATH.ROOT,

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 import { BACKEND_ENDPOINT } from '../constants/endPoint';
 import { ApiError } from './customError';
+import { tokenStorage } from '../lib/tokenStorage';
 
 const apiClient = axios.create({
   baseURL: BACKEND_ENDPOINT,
@@ -13,7 +14,7 @@ const apiClient = axios.create({
 
 apiClient.interceptors.request.use(
   (config) => {
-    const accessToken = window.localStorage.getItem('token');
+    const accessToken = tokenStorage.getToken();
     config.headers['Authorization'] = `Bearer ${accessToken}`;
 
     return config;

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -8,11 +8,25 @@ const apiClient = axios.create({
   headers: {
     accept: 'application/json',
   },
+  withCredentials: true,
 });
+
+apiClient.interceptors.request.use(
+  (config) => {
+    const accessToken = window.localStorage.getItem('token');
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
+
+    return config;
+  },
+  (error: Error) => {
+    console.log(error);
+    return Promise.reject(error);
+  }
+);
 
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
+  (error: Error) => {
     if (axios.isAxiosError(error)) {
       const message = error.response?.data.message || error.message;
       const status = error.response?.status || 500;

--- a/src/shared/constants/endPoint.ts
+++ b/src/shared/constants/endPoint.ts
@@ -14,5 +14,5 @@ export const END_POINT = {
   UPLOADER_GRID: '/api/grid/:userId',
   FAMILY: (petId: string) => `/api/family/${petId}`,
   INVITE_MEMBER: (petId: string) => `/api/family/${petId}/member`,
-  KAKAO_TOKEN: '/auth/kakao-login-page',
+  KAKAO_LOGIN: '/auth/kakao-login',
 } as const;

--- a/src/shared/lib/tokenStorage.ts
+++ b/src/shared/lib/tokenStorage.ts
@@ -1,0 +1,7 @@
+const ACCESS_TOKEN = 'access_token';
+
+export const tokenStorage = {
+  getToken: () => window.localStorage.getItem(ACCESS_TOKEN),
+  setToken: (token: string) => window.localStorage.setItem(ACCESS_TOKEN, token),
+  clearToken: () => window.localStorage.removeItem(ACCESS_TOKEN),
+};


### PR DESCRIPTION
### 관련 문서

<!--이슈 링크-->
<!--Closes 뒤에 본 PR을 머지하면 close할 issue number를 적어주세요.-->

Closes #92 

### 변경사항:

<!--중요 커밋은 링크로 연결해서 추가-->
- 소셜로그인 인가코드 수신을 프론트에서 진행하는 것으로 변경합니다. : #92 
   - 소셜로그인에서 토큰 발급 진행시, 사용자에게 실시간 로딩 상태를 보여주기 위합니다. 
- 현재 MSW mock API로 진행하기 위해 발급받은 refresh token은 httpOnly :Secure을 진행하지 않았습니다.


### 확인할 목록:

<!--리뷰어에게 부탁할 확인 목록 및 테스트 방법을 작성-->
- access token 만료될 경우 재발급 받는 로직이 필요합니다. 
    - 현재 accss token 만료여부를 확인하는 방법이 논의되지 못했습니다.
- 추후에, 펫등록이 되어있지 않는 유저는 펫등록페이지(register)로 리디렉션을 시켜줘야 합니다.
    - 현재 관련된 api 명세가 존재하지 않습니다.